### PR TITLE
Fix duplicate runApp call

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,6 @@ void main() async {
 //  await Firebase.initializeApp(
 //!  options: DefaultFirebaseOptions.currentPlatform,
   runApp(const MyApp());
-  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
## Summary
- remove the extra `runApp` invocation in `main.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684638bda7648325ab0bcb38d0ec5842