### PR TITLE
Fix proximospassos navigation target

### DIFF
--- a/lib/screens/proximos_passos.dart
+++ b/lib/screens/proximos_passos.dart
@@ -27,7 +27,7 @@ class ProximosPassos extends StatelessWidget {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
-                Navigator.pushReplacementNamed(context, '/');
+                Navigator.pushReplacementNamed(context, '/home');
               },
               style: ElevatedButton.styleFrom(
                   foregroundColor: Colors.blue, backgroundColor: Colors.white),


### PR DESCRIPTION
## Summary
- update `/` target to `/home` for returning to main screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684638c517448325bb74087421253008